### PR TITLE
Add alt text field for describing user images

### DIFF
--- a/components/GeneratorPage/GeneratorPage.tsx
+++ b/components/GeneratorPage/GeneratorPage.tsx
@@ -92,7 +92,8 @@ export const GeneratorPage: React.FC<GeneratorPageProps> = ({ generator }) => {
       const buffer = Buffer.from(data, 'base64');
       const newBuffer = writeMetadata(buffer, {
         iTXt: {
-          Description: suggestedAltText || '',
+          Description:
+            suggestedAltText?.replaceAll('{{userImage}}', 'an image') || '',
           Software: 'imagenerator.net',
         },
       });

--- a/components/ImageField/ImageField.module.css
+++ b/components/ImageField/ImageField.module.css
@@ -1,3 +1,9 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .dropzone {
   display: flex;
   flex-direction: row;
@@ -36,4 +42,14 @@
 
 .cropWrapper {
   padding-top: 12px;
+}
+
+.altTextWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.altTextField {
+  width: 100%;
 }

--- a/components/ImageField/ImageField.tsx
+++ b/components/ImageField/ImageField.tsx
@@ -12,12 +12,15 @@ import { Image } from '../../types/Image';
 import { Button } from '../Button';
 import { Expander } from '../Expander';
 import { ImageCrop } from '../ImageCrop';
+import { TextField } from '../TextField';
 
 import styles from './ImageField.module.css';
 
 interface ImageFieldProps {
   value: Image;
   onChange: (value: Image | undefined) => void;
+  id: string;
+  name: string;
   allowCrop?: boolean;
   cropAspectRatio?: number;
   cropMinWidth?: number;
@@ -27,6 +30,8 @@ interface ImageFieldProps {
 export const ImageField = ({
   value = {},
   onChange,
+  id,
+  name,
   allowCrop,
   cropAspectRatio,
   cropMinWidth,
@@ -60,50 +65,61 @@ export const ImageField = ({
   });
 
   return (
-    <Expander
-      renderTrigger={(toggle) => (
-        <div {...getRootProps()} className={styles.dropzone}>
-          <input {...getInputProps()} />
-          <div className={styles.preview} onClick={open}>
-            {value.src ? (
-              <img className={styles.previewImage} src={value.src} alt="" />
-            ) : (
-              <IoImage width={48} height={48} />
+    <div className={styles.wrapper}>
+      <Expander
+        renderTrigger={(toggle) => (
+          <div {...getRootProps()} className={styles.dropzone}>
+            <input {...getInputProps()} />
+            <div className={styles.preview} onClick={open}>
+              {value.src ? (
+                <img className={styles.previewImage} src={value.src} alt="" />
+              ) : (
+                <IoImage width={48} height={48} />
+              )}
+            </div>
+            <Button
+              className={styles.button}
+              onClick={open}
+              icon={value.src ? IoSwapHorizontalOutline : IoFolderOutline}>
+              <span>{value.src ? 'Replace' : 'Choose an image'}</span>
+            </Button>
+            {!!value.src && (
+              <Button
+                className={styles.clearButton}
+                onClick={clearImage}
+                icon={IoTrashOutline}
+              />
+            )}
+            {allowCrop && !!value.src && (
+              <Button
+                className={styles.clearButton}
+                onClick={toggle}
+                icon={IoCropOutline}
+              />
             )}
           </div>
-          <Button
-            className={styles.button}
-            onClick={open}
-            icon={value.src ? IoSwapHorizontalOutline : IoFolderOutline}>
-            <span>{value.src ? 'Replace' : 'Choose an image'}</span>
-          </Button>
-          {!!value.src && (
-            <Button
-              className={styles.clearButton}
-              onClick={clearImage}
-              icon={IoTrashOutline}
+        )}>
+        {allowCrop && !!value.src && (
+          <div className={styles.cropWrapper}>
+            <ImageCrop
+              image={value.src}
+              aspectRatio={cropAspectRatio}
+              minWidth={cropMinWidth}
+              minHeight={cropMinHeight}
+              onSave={(crop) => onChange({ ...value, crop })}
             />
-          )}
-          {allowCrop && !!value.src && (
-            <Button
-              className={styles.clearButton}
-              onClick={toggle}
-              icon={IoCropOutline}
-            />
-          )}
-        </div>
-      )}>
-      {allowCrop && !!value.src && (
-        <div className={styles.cropWrapper}>
-          <ImageCrop
-            image={value.src}
-            aspectRatio={cropAspectRatio}
-            minWidth={cropMinWidth}
-            minHeight={cropMinHeight}
-            onSave={(crop) => onChange({ ...value, crop })}
-          />
-        </div>
-      )}
-    </Expander>
+          </div>
+        )}
+      </Expander>
+      <div className={styles.altTextWrapper}>
+        <label htmlFor={`${id}-alt-text`}>{name} alt text</label>
+        <TextField
+          id={`${id}-alt-text`}
+          className={styles.altTextField}
+          value={value.altText || ''}
+          onChange={(newValue) => onChange({ ...value, altText: newValue })}
+        />
+      </div>
+    </div>
   );
 };

--- a/components/SettingRenderer/SettingRenderer.tsx
+++ b/components/SettingRenderer/SettingRenderer.tsx
@@ -49,6 +49,8 @@ export const SettingRenderer: React.FC<SettingRendererProps> = ({
     case SettingType.Image:
       return (
         <ImageField
+          id={id}
+          name={setting.name}
           onChange={onChange}
           value={value}
           allowCrop={setting.params.allowCrop}

--- a/generators/Boykisser/buildAltText.ts
+++ b/generators/Boykisser/buildAltText.ts
@@ -5,7 +5,9 @@ export const buildAltText = (settings: SettingValues<BoykisserSettings>) => {
   const { text, image } = settings;
 
   const imageDescription = image.src
-    ? "{{userImage}} with a smug face on top that's blushing"
+    ? image.altText
+      ? `${image.altText} with a smug face on top that's blushing`
+      : "{{userImage}} with a smug face on top that's blushing"
     : 'A line drawing of a cat making a smug face and blushing';
 
   const textDescription = text

--- a/generators/GameBoyCamera/buildAltText.ts
+++ b/generators/GameBoyCamera/buildAltText.ts
@@ -1,0 +1,12 @@
+import { SettingValues } from '../../types/SettingTypes';
+import { GameBoyCameraSettings } from './types';
+
+export const buildAltText = (
+  settings: SettingValues<GameBoyCameraSettings>
+) => {
+  const { image } = settings;
+
+  const imageDesc = image.altText || '{{userImage}}';
+
+  return `${imageDesc}. The picture has been edited to look like it was taken with a game boy camera, so it uses a palette of four colours and has a low resolution pixellated effect.`;
+};

--- a/generators/GameBoyCamera/generate.ts
+++ b/generators/GameBoyCamera/generate.ts
@@ -3,6 +3,7 @@ import { applyCrop } from '../../utils/applyCrop';
 import { loadImage } from '../../utils/loadImage';
 
 import { applyDithering } from './applyDithering';
+import { buildAltText } from './buildAltText';
 import {
   BRIGHTNESS_MAP,
   CONTRAST_MAP,
@@ -62,9 +63,10 @@ export const generate: GeneratorFunction<GameBoyCameraSettings> = async (
 
   ctx.putImageData(upscale(pixels), 0, 0);
 
+  const suggestedAltText = buildAltText(settings);
+
   return {
     success: true,
-    suggestedAltText:
-      '{{userImage}}. The picture has been edited to look like it was taken with a game boy camera, so it uses a palette of four colours and has a low resolution pixellated effect.',
+    suggestedAltText,
   };
 };

--- a/generators/NounVerbed/buildAltText.ts
+++ b/generators/NounVerbed/buildAltText.ts
@@ -1,0 +1,15 @@
+import { SettingValues } from '../../types/SettingTypes';
+import { NounVerbedSettings } from './types';
+
+export const buildAltText = (settings: SettingValues<NounVerbedSettings>) => {
+  const { image, text, colour } = settings;
+
+  const imageDesc = image.altText || '{{userImage}}';
+
+  const colourName = colour.name.toLowerCase();
+  const textDesc = text
+    ? `with the text "${text.toUpperCase()}" on top in a ${colourName} font, to look like a Dark Souls "YOU DIED" screenshot.`
+    : 'with an empty translucent banner across it.';
+
+  return `${imageDesc} ${textDesc}`;
+};

--- a/generators/NounVerbed/generate.ts
+++ b/generators/NounVerbed/generate.ts
@@ -1,6 +1,7 @@
 import { GeneratorFunction } from '../../types/GeneratorTypes';
 import { loadImage } from '../../utils/loadImage';
 import { calculateImageSize } from '../../utils/resizeImage';
+import { buildAltText } from './buildAltText';
 
 import { TARGET_SIZE, MAX_FONT_SIZE } from './constants';
 import { NounVerbedSettings } from './types';
@@ -70,9 +71,9 @@ export const generate: GeneratorFunction<NounVerbedSettings> = async (
   ctx.font = `${fontSize} 'Optimus Princeps'`;
   ctx.fillText(uppercaseText, width / 2, (height / 100) * textPosition);
 
+  const suggestedAltText = buildAltText(settings);
+
   return {
-    suggestedAltText:
-      `{{userImage}} with the text "${uppercaseText}" on top in a ` +
-      `${colour.name.toLowerCase()} serif font, to look like a dark souls "you died" screenshot.`,
+    suggestedAltText,
   };
 };

--- a/generators/TheyLive/buildAltText.ts
+++ b/generators/TheyLive/buildAltText.ts
@@ -1,0 +1,17 @@
+import { SettingValues } from '../../types/SettingTypes';
+import { TheyLiveSettings } from './types';
+
+export const buildAltText = (settings: SettingValues<TheyLiveSettings>) => {
+  const { topImage, bottomImage } = settings;
+
+  const topImageDesc = topImage.altText || '{{userImage}}';
+  const bottomImageDesc = bottomImage.altText || '{{userImage}}';
+
+  return (
+    'A four panel meme with shots from the movie They Live. ' +
+    "In the first panel, the main character (played by Roddy Piper) is holding a pair of sunglasses partially off his face, so that he's looking over them. " +
+    `The next panel is ${topImageDesc}. ` +
+    "In the third panel, he has put the sunglasses on so he's looking through them. " +
+    `The final panel is ${bottomImageDesc}, in black and white.`
+  );
+};

--- a/generators/TheyLive/generate.ts
+++ b/generators/TheyLive/generate.ts
@@ -1,6 +1,7 @@
 import { GeneratorFunction } from '../../types/GeneratorTypes';
 import { applyCrop } from '../../utils/applyCrop';
 import { loadImage } from '../../utils/loadImage';
+import { buildAltText } from './buildAltText';
 import { BORDER_WIDTH, IMAGE_SIZE, OUTPUT_SIZE } from './constants';
 import { convertToGreyscale } from './convertToGreyscale';
 import { TheyLiveCache, TheyLiveSettings } from './types';
@@ -86,12 +87,7 @@ export const generate: GeneratorFunction<
     }
   }
 
-  const suggestedAltText =
-    'A four panel meme with shots from the movie They Live. ' +
-    "In the first panel, the main character (played by Roddy Piper) is holding a pair of sunglasses partially off his face, so that he's looking over them. " +
-    'The next panel is {{userImage}}. ' +
-    "In the third panel, he has put the sunglasses on so he's looking through them. " +
-    'The final panel is {{userImage}}, in black and white.';
+  const suggestedAltText = buildAltText(settings);
 
   return {
     success: true,

--- a/generators/TomScott/buildAltText.ts
+++ b/generators/TomScott/buildAltText.ts
@@ -1,0 +1,14 @@
+import { SettingValues } from '../../types/SettingTypes';
+import { TomScottSettings } from './types';
+
+export const buildAltText = (settings: SettingValues<TomScottSettings>) => {
+  const { image, text } = settings;
+
+  const imageDesc = image.altText || '{{userImage}}';
+
+  const textDesc = text
+    ? `with text on top with a red background that says "${text.toLowerCase()}"`
+    : 'with an empty red rectangle on top';
+
+  return `${imageDesc} ${textDesc} and a small arrow. It's designed to look like a thumbnail for a Tom Scott video.`;
+};

--- a/generators/TomScott/generate.ts
+++ b/generators/TomScott/generate.ts
@@ -13,6 +13,7 @@ import {
   TEXT_PADDING,
 } from './constants';
 import { TomScottSettings } from './types';
+import { buildAltText } from './buildAltText';
 
 export const generate: GeneratorFunction<TomScottSettings> = async (
   canvas,
@@ -141,7 +142,7 @@ export const generate: GeneratorFunction<TomScottSettings> = async (
     height
   );
 
-  const suggestedAltText = `{{userImage}} with text on top with a red background that says "${lowercaseText}". There's an arrow pointing at [describe what the arrow is pointing at].`;
+  const suggestedAltText = buildAltText(settings);
 
   return {
     success: true,

--- a/generators/TopBottomText/buildAltText.ts
+++ b/generators/TopBottomText/buildAltText.ts
@@ -4,19 +4,21 @@ import { TopBottomTextSettings } from './types';
 export const buildAltText = (
   settings: SettingValues<TopBottomTextSettings>
 ) => {
-  const { topText, bottomText } = settings;
+  const { topText, bottomText, image } = settings;
+
+  const imageDesc = image.altText || '{{userImage}}';
 
   if (!topText && !bottomText) {
-    return '{{userImage}}';
+    return imageDesc;
   }
 
   if (topText && !bottomText) {
-    return `A meme with the text "${topText}" above an image of {{userImage}}.`;
+    return `A meme with the text "${topText}" above ${imageDesc}.`;
   }
 
   if (!topText && bottomText) {
-    return `A meme with an image of {{userImage}} and text below it that says "${bottomText}".`;
+    return `A meme with ${imageDesc} and text below it that says "${bottomText}".`;
   }
 
-  return `A meme with text above and below an image. The text at the top says "${topText}". The image is {{userImage}}. The text below the image says "${bottomText}".`;
+  return `A meme with text above and below an image. The text at the top says "${topText}". The image is ${imageDesc}. The text below the image says "${bottomText}".`;
 };

--- a/generators/Yakuza/buildAltText.ts
+++ b/generators/Yakuza/buildAltText.ts
@@ -2,14 +2,15 @@ import { SettingValues } from '../../types/SettingTypes';
 import { YakuzaSettings } from './types';
 
 export const buildAltText = (settings: SettingValues<YakuzaSettings>) => {
-  const { name, title } = settings;
+  const { name, title, image } = settings;
 
   if (!name && !title) {
     return undefined;
   }
 
-  const firstLine =
-    '{{userImage}} with text on top in a red handwriting style font styled like a character intro screen from a Yakuza game. ';
+  const imageDesc = image.altText || '{{userImage}}';
+
+  const firstLine = `${imageDesc} with text on top in a red handwriting style font styled like a character intro screen from a Yakuza game. `;
 
   if (name && title) {
     return (

--- a/types/Image.ts
+++ b/types/Image.ts
@@ -3,4 +3,5 @@ import { Crop } from 'react-image-crop';
 export interface Image {
   src?: string;
   crop?: Crop;
+  altText?: string;
 }


### PR DESCRIPTION
As part of the `ImageField` component, render an additional text field so the user can describe the image they've chosen. This improves the embedded alt text in the exif data of the generated image.

Closes #64