### PR TITLE
Remove template tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-generator_idea.md
+++ b/.github/ISSUE_TEMPLATE/01-generator_idea.md
@@ -1,7 +1,7 @@
 ---
 name: Generator idea
 about: Suggest a idea for a new generator
-title: "[Generator idea]"
+title: ""
 labels: generator idea
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/02-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Let me know about a problem
-title: "[bug]"
+title: ""
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/03-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/03-feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an improvement
-title: "[Feature request]"
+title: ""
 labels: feature
 assignees: ''
 


### PR DESCRIPTION
The templates add labels, why do we need tags in the titles? We don’t 