### PR TITLE
Fix “not what I’m called” alt text

### DIFF
--- a/generators/NotWhatImCalled/buildAltText.ts
+++ b/generators/NotWhatImCalled/buildAltText.ts
@@ -8,7 +8,7 @@ export const buildAltText = (
 
   return (
     `${image.description} saying "hey guys" with three people looking over and pointing. ` +
-    `The characters shout "${name}"` +
-    'and the response is "not what I\'m called.'
+    `The characters shout "${name}" ` +
+    'and the response is "not what I\'m called".'
   );
 };


### PR DESCRIPTION
Add a missing space and closing double-quote.